### PR TITLE
fix(autocomplete): preserve search on non-inline tab switch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-core-ts",
-  "version": "2.1.33",
+  "version": "2.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-core-ts",
-      "version": "2.1.33",
+      "version": "2.1.35",
       "license": "ISC",
       "dependencies": {
         "@babel/plugin-transform-typescript": "^7.22.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-core-ts",
-  "version": "2.1.34",
+  "version": "2.1.35",
   "description": "React Components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/AutoCompleteWithSelectedList.tsx
+++ b/src/AutoCompleteWithSelectedList.tsx
@@ -404,10 +404,11 @@ const AutoCompleteWithSelectedList = forwardRef<
       }
     };
 
-    const handleClearSelected = () => {
+    const handleClearSelected = (preserveSearchOrEvent?: boolean | React.MouseEvent<HTMLElement>) => {
+      const preserveSearch = typeof preserveSearchOrEvent === 'boolean' ? preserveSearchOrEvent : false;
       setSelectedItems([]);
       setShowAllSelected(false);
-      if (searchValue && type === 'auto_suggestion') {
+      if (!preserveSearch && searchValue && type === 'auto_suggestion') {
         setSearchValue('');
         if(!tabInlineSearch) {
           onSearchValueChange?.('');
@@ -745,7 +746,7 @@ const AutoCompleteWithSelectedList = forwardRef<
     const handleTabClick = (index: number) => {
       if (activeTab !== index) {
         if (clearTabSwitch) {
-          handleClearSelected();
+          handleClearSelected(!tabInlineSearch);
           if (tabInlineSearch) {
             setSearchValue('');
             setInputValue('');

--- a/src/AutoCompleteWithTabFilter.tsx
+++ b/src/AutoCompleteWithTabFilter.tsx
@@ -299,17 +299,18 @@ const AutoCompleteWithTabFilter = forwardRef<
             setAllDataLoaded(false);
         }, [handleChangeWithDebounce]);
 
-        const handleClearSelected = useCallback(() => {
+        const handleClearSelected = useCallback((preserveSearchOrEvent?: boolean | React.MouseEvent<HTMLElement>) => {
+            const preserveSearch = typeof preserveSearchOrEvent === 'boolean' ? preserveSearchOrEvent : false;
             setSelectedItems([]);
             setShowAllSelected(false);
             setShowToolsTab(false);
-            if (searchValue && type === 'auto_suggestion' && (tabInlineSearch || resetAllSearch)) {
+            if (!preserveSearch && searchValue && type === 'auto_suggestion' && (tabInlineSearch || resetAllSearch)) {
                 setSearchValue('');
             }
             if (isMultiple) onChange([]);
             else onChange({ [descId]: '', [desc]: '' });
             if (async && type === 'auto_suggestion' && (tabInlineSearch || resetAllSearch)) resetSuggections?.();
-        }, [searchValue, type, tabInlineSearch, isMultiple, onChange, descId, desc, async, resetSuggections]);
+        }, [searchValue, type, tabInlineSearch, isMultiple, onChange, descId, desc, async, resetSuggections, resetAllSearch]);
 
         const generateClassName = useCallback(() => {
             return `qbs-textfield-default ${className} ${errors && errors?.message ? 'textfield-error' : 'textfield'
@@ -822,7 +823,7 @@ const AutoCompleteWithTabFilter = forwardRef<
         const handleTabClick = useCallback((index: number) => {
             if (activeTab !== index) {
                 if (clearTabSwitch) {
-                    handleClearSelected();
+                    handleClearSelected(!tabInlineSearch);
                     if (tabInlineSearch) {
                         setSearchValue('');
                         setInputValue('');


### PR DESCRIPTION
Keep the search key when switching tabs with tabInlineSearch disabled and bump package version to 2.1.35 for release consistency.