### PR TITLE
fix(autocomplete): refine tab-switch search behavior and bump version

### DIFF
--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -493,7 +493,7 @@ export default function App() {
               ]}
               clearTabSwitch={true}
               tabInlineSearch={false}
-              // autoDropdown={true}
+              autoDropdown={true}
               searchValue="Hello"
               onSearchValueChange={(value) =>
                 console.log(value, "onSearchValueChange")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-core-ts",
-  "version": "2.1.35",
+  "version": "2.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-core-ts",
-      "version": "2.1.35",
+      "version": "2.1.36",
       "license": "ISC",
       "dependencies": {
         "@babel/plugin-transform-typescript": "^7.22.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-core-ts",
-  "version": "2.1.35",
+  "version": "2.1.36",
   "description": "React Components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/AutoCompleteWithSelectedList.tsx
+++ b/src/AutoCompleteWithSelectedList.tsx
@@ -751,17 +751,27 @@ const AutoCompleteWithSelectedList = forwardRef<
             setSearchValue('');
             setInputValue('');
             handlePickSuggestions('', 1);
+            setAllDataLoaded(false);
           } else {
             resetSuggections?.();
             const activeTabVal =
               tab.length > 0 ? tab?.[index].id : undefined;
-            handlePickSuggestions(searchValue, 1, false, activeTabVal);
+            const normalizedSearchValue = searchValue?.trim();
+            const tabSearchValue =
+              !tabInlineSearch && allDataLoaded && !normalizedSearchValue
+                ? '*'
+                : searchValue;
+            handlePickSuggestions(tabSearchValue, 1, false, activeTabVal);
           }
-          setAllDataLoaded(false);
         } else if (!tabInlineSearch) {
           resetSuggections?.();
           const activeTabVal = tab.length > 0 ? tab?.[index].id : undefined;
-          handlePickSuggestions(searchValue, 1, false, activeTabVal);
+          const normalizedSearchValue = searchValue?.trim();
+          const tabSearchValue =
+            !tabInlineSearch && allDataLoaded && !normalizedSearchValue
+              ? '*'
+              : searchValue;
+          handlePickSuggestions(tabSearchValue, 1, false, activeTabVal);
         }
         setActiveTab(index);
       }

--- a/src/AutoCompleteWithTabFilter.tsx
+++ b/src/AutoCompleteWithTabFilter.tsx
@@ -828,21 +828,31 @@ const AutoCompleteWithTabFilter = forwardRef<
                         setSearchValue('');
                         setInputValue('');
                         handlePickSuggestions('', 1);
+                        setAllDataLoaded(false);
                     } else {
                         resetSuggections?.();
                         const activeTabVal =
                             tab.length > 0 ? tab?.[index].id : undefined;
-                        handlePickSuggestions(searchValue, 1, false, activeTabVal);
+                        const normalizedSearchValue = searchValue?.trim();
+                        const tabSearchValue =
+                            !tabInlineSearch && allDataLoaded && !normalizedSearchValue
+                                ? '*'
+                                : searchValue;
+                        handlePickSuggestions(tabSearchValue, 1, false, activeTabVal);
                     }
-                    setAllDataLoaded(false);
                 } else if (!tabInlineSearch) {
                     resetSuggections?.();
                     const activeTabVal = tab.length > 0 ? tab?.[index].id : undefined;
-                    handlePickSuggestions(searchValue, 1, false, activeTabVal);
+                    const normalizedSearchValue = searchValue?.trim();
+                    const tabSearchValue =
+                        !tabInlineSearch && allDataLoaded && !normalizedSearchValue
+                            ? '*'
+                            : searchValue;
+                    handlePickSuggestions(tabSearchValue, 1, false, activeTabVal);
                 }
                 setActiveTab(index);
             }
-        }, [activeTab, clearTabSwitch, handleClearSelected, tabInlineSearch, tab, searchValue, handlePickSuggestions, resetSuggections]);
+        }, [activeTab, clearTabSwitch, handleClearSelected, tabInlineSearch, tab, searchValue, handlePickSuggestions, resetSuggections, allDataLoaded]);
 
         const getSelectedRowLimit = useCallback(() => {
             let maxHeight = 36;

--- a/src/dropdownFilterTabs.tsx
+++ b/src/dropdownFilterTabs.tsx
@@ -788,22 +788,32 @@ const DropdownFilterTabs = forwardRef<
             setSearchValue('');
             setInputValue('');
             handlePickSuggestions('', 1);
+            setAllDataLoaded(false);
           } else {
             resetSuggections?.();
             const activeTabVal =
               tab.length > 0 ? tab?.[index].id : undefined;
-            handlePickSuggestions(searchValue, 1, false, activeTabVal);
+            const normalizedSearchValue = searchValue?.trim();
+            const tabSearchValue =
+              !tabInlineSearch && allDataLoaded && !normalizedSearchValue
+                ? '*'
+                : searchValue;
+            handlePickSuggestions(tabSearchValue, 1, false, activeTabVal);
           }
-          setAllDataLoaded(false);
         } else {
           resetSuggections?.();
           const activeTabVal = tab.length > 0 ? tab?.[index].id : undefined;
-          handlePickSuggestions(searchValue, 1, false, activeTabVal);
+          const normalizedSearchValue = searchValue?.trim();
+          const tabSearchValue =
+            !tabInlineSearch && allDataLoaded && !normalizedSearchValue
+              ? '*'
+              : searchValue;
+          handlePickSuggestions(tabSearchValue, 1, false, activeTabVal);
         }
         setActiveTab(index);
         setFocusedIndex(0); // Reset focused index when switching tabs
       }
-    }, [activeTab, clearTabSwitch, handleClearSelected, tabInlineSearch, tab, searchValue, handlePickSuggestions, resetSuggections]);
+    }, [activeTab, clearTabSwitch, handleClearSelected, tabInlineSearch, tab, searchValue, handlePickSuggestions, resetSuggections, allDataLoaded]);
 
     const getSelectedRowLimit = useCallback(() => {
       let maxHeight = 36;


### PR DESCRIPTION
Apply tab switch query handling updates for non-inline search and bump package version to 2.1.36.

Made-with: Cursor